### PR TITLE
Debug log level for drops due to UDP w/checksum 0

### DIFF
--- a/mod/common/packet.c
+++ b/mod/common/packet.c
@@ -455,8 +455,8 @@ static int handle_udp4(struct sk_buff *skb, struct pkt_metadata *meta)
 	 */
 	if (ptr->check == 0 && (is_more_fragments_set_ipv4(hdr4)
 			|| !config_get_compute_UDP_csum_zero())) {
-		log_info("Dropping IPv4 packet, UDP Packet has checksum 0:");
-		log_info("%pI4#%u->%pI4#%u", &hdr4->saddr, ntohs(ptr->source),
+		log_debug("Dropping IPv4 packet, UDP Packet has checksum 0:");
+		log_debug("%pI4#%u->%pI4#%u", &hdr4->saddr, ntohs(ptr->source),
 				&hdr4->daddr, ntohs(ptr->dest));
 		return -EINVAL;
 	}


### PR DESCRIPTION
Reduce the log level for packet drops due to inbound IPv4 packets having
UDP checksum 0 to debug. This is to avoid the kernel ring buffer and
console being flooded with mostly useless messages, drowning out more
interesting messages.

For what it's worth, my Jool test node with an IPv4 /24 routed to it has
accumulated over 2700 of these log lines in less than two days of uptime.
It's caused by normal internet background radiation (e.g., bots scanning
for open UDP services they can abuse to amplify volumetric DDoS attacks).