### PR TITLE
Use /96 translation prefix instead of /64

### DIFF
--- a/doc/usr/misc-rfc6791.md
+++ b/doc/usr/misc-rfc6791.md
@@ -7,7 +7,7 @@ title: Documentation - RFC 6791
 
 # RFC 6791
 
-Suppose _n4_ is trying to reach _n6_, but there is a problem (eg. the packet is too big), and _R_ sends _n4_ an ICMP error. _T_ is translating using prefix 2001:db8::/64.
+Suppose _n4_ is trying to reach _n6_, but there is a problem (eg. the packet is too big), and _R_ sends _n4_ an ICMP error. _T_ is translating using prefix 2001:db8::/96.
 
 ![Figure 1 - Network](images/network/rfc6791.svg)
 


### PR DESCRIPTION
The IPv4-translatable IPv6 address in the table clearly encodes the IPv4
address in bits 96-127, while the text above says that the translation
prefix is a /64. One of them must therefore be incorrect. Quoting from
RFC6052 section 2.3:

```
   o  When the prefix is 64 bits long, the IPv4 address is encoded in
      positions 72 to 103.

   o  When the prefix is 96 bits long, the IPv4 address is encoded in
      positions 96 to 127.
```