### PR TITLE
Add support for the DKMS framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ install-sh
 missing
 Makefile
 
+# DKMS version cache
+######################
+dkms.package_version.conf

--- a/INSTALL
+++ b/INSTALL
@@ -14,13 +14,19 @@ Install the requirements:
 		# apt-get install libnl-3-dev
 		(Site: http://www.carisma.slowglass.com/~tgr/libnl)
 
-Compile the module:
-	NAT64$ cd mod
-	NAT64/mod$ make
+Installing the modules using Dynamic Kernel Module Support (DKMS):
+	1. Ensure the DKMS framework is installed:
+		# apt-get install dkms
+	2. Add Jool to the DKMS framework (builds and installs the modules):
+		# dkms install /path/to/NAT64
 
-Install the module:
-	NAT64/mod# make modules_install
-	# depmod
+Alternatively, manually install the modules using Kbuild directly:
+	1. Compile the modules:
+		NAT64$ cd mod
+		NAT64/mod$ make
+	2. Install the modules:
+		NAT64/mod# make modules_install
+		# depmod
 
 Insert the module:
 	Configure networking.

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,88 @@
+# dkms.conf: Dynamic Kernel Module Support (DKMS) configuration file for Jool.
+#
+# The use of DKMS ensures that the Jool kernel modules will be rebuilt
+# whenever the kernel is upgraded.
+#
+# Installation instructions:
+#   root@host:~# dkms install /path/to/NAT64
+#
+# You should normally not need to edit any of the lines in this file. The
+# meanings of the various directives below are documented in DKMS(8).
+
+PACKAGE_NAME="jool"
+
+# DKMS is quite finicky about the contents of the $PACKAGE_VERSION string. It
+# will source dkms.conf every time it performs a task, but if the contents
+# $PACKAGE_VERSION changes between runs, it fails to work correctly. Since we
+# might dynamically generate the version string (based on output from
+# "git describe" or "date"), we make sure to generate it only once and save
+# the result in a cache file so it can be re-used later.
+
+# Determine where the actual source tree we're working on is located.
+# $BASH_SOURCE holds the full path to dkms.conf, which resides in the
+# apex of Jool's source tree. So we just have to strip off "/dkms.conf".
+SRCDIR="${BASH_SOURCE%/dkms.conf}"
+
+# This cache file will hold the generated $PACKAGE_VERSION string.
+VERSIONFILE="${SRCDIR}/dkms.package_version.conf"
+
+# If necessary (i.e., if we do not have a cache file at this point), then
+# determine the DKMS version string and store it in the cache file.
+if test ! -e "${VERSIONFILE}"; then
+  # First, determine the main Jool version based on macros in nat64.h
+  eval "$(sed -n '/^#define  *JOOL_VERSION_\(MAJOR\|MINOR\|REV\) / {
+                    s/^#define  *//;
+                    s/  */=/p;
+                  }' ${SRCDIR}/include/nat64/common/nat64.h)"
+
+  if test ! -z "$JOOL_VERSION_MAJOR" -a ! -z "$JOOL_VERSION_MINOR" -a \
+          ! -z "$JOOL_VERSION_REV"; then
+    # OK, we successfully determined the main Jool version.
+    JOOLVER="${JOOL_VERSION_MAJOR}.${JOOL_VERSION_MINOR}.${JOOL_VERSION_REV}"
+  else
+    # We failed to determine the main Jool version. Maybe nat64.h changed
+    # syntax or the JOOL_VERSION_* macros were moved elsewhere? In any case
+    # just use a dummy version string (which must start with a digit,
+    # otherwise "dkms mkdeb" won't work).
+    JOOLVER="0unknown"
+  fi
+
+  # If we're working on a Git checkout, we'll also want to include output
+  # from "git describe" in the DKMS version string.
+  if test -d "${SRCDIR}/.git"; then
+    # We need to replace '-' with '.' in order to make "dkms mkrpm" and
+    # "dkms mkdeb" to work correctly.
+    GITVER="$(git -C "${SRCDIR}" describe --always | tr - . 2>/dev/null)"
+    # In the unlikely event that "git describe" fails (maybe the admin
+    # has uninstalled git?), we'll use a date-based string instead.
+    test -z "${GITVER}" && GITVER="$(date +%Y%m%d)"
+    # Prepend ".git." to Git version string so its origin is clear.
+    GITVER=".git.${GITVER}"
+  fi
+
+  # All done - now store the generated version string for later use.
+  echo "# Automatically generated from dkms.conf on $(date -R)" > \
+         "${VERSIONFILE}"
+  echo "PACKAGE_VERSION=${JOOLVER}${GITVER}" >> "${VERSIONFILE}"
+fi
+
+# At this point we should be able to read in the previously generated
+# $PACKAGE_VERSION string from the cache file. If this fails, DKMS will
+# simply fail and complain that the dkms.conf did not set $PACKAGE_VERSION.
+. "${VERSIONFILE}"
+
+# This instructs DKMS to rebuild the Jool kernel modules when necessary,
+# such as after a kernel upgrade.
+AUTOINSTALL="yes"
+
+MAKE[0]="make -C ${kernel_source_dir} SUBDIRS=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/mod/stateful modules && make -C ${kernel_source_dir} SUBDIRS=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/mod/stateless modules"
+
+CLEAN="make -C ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/mod clean"
+
+BUILT_MODULE_NAME[0]="jool"
+BUILT_MODULE_LOCATION[0]="mod/stateful/"
+DEST_MODULE_LOCATION[0]="/extra/"
+
+BUILT_MODULE_NAME[1]="jool_siit"
+BUILT_MODULE_LOCATION[1]="mod/stateless/"
+DEST_MODULE_LOCATION[1]="/extra/"

--- a/doc/usr/mod-install.md
+++ b/doc/usr/mod-install.md
@@ -11,8 +11,9 @@ title: Documentation - Kernel Modules Installation
 
 1. [Introduction](#introduction)
 2. [Requirements](#requirements)
-3. [Compilation](#compilation)
-4. [Installation](#installation)
+3. [Installation](#installation)
+   1. [DKMS](#dkms)
+   2. [Kbuild](#kbuild)
 
 ## Introduction
 
@@ -54,7 +55,7 @@ Finally, you need your kernel headers. If you're using apt-get, just run this:
 $ apt-get install linux-headers-$(uname -r)
 {% endhighlight %}
 
-## Compilation
+## Installation
 
 Each kernel version combined with each different architecture requires different binaries, so providing packages for every combination would be impossibly cumbersome. For this reason, what you'll download is the source; there is no way around compiling the code yourself.
 
@@ -65,9 +66,29 @@ To download Jool, you have two options:
 * Official releases are hosted in the [Download page](download.html). These will prove less convoluted when you're installing the userspace application.
 * There's the <a href="https://github.com/NICMx/NAT64" target="_blank">Github repository</a>. This might have slight bugfixes not present in the latest official release, which you can access by sticking to the latest commit of the master branch (in case you're wondering, we do all the risky development elsewhere).
 
-You might be used to a standard three-step procedure to compile and install programs: `./configure && make && make install`. Kernel modules do not follow it, but have a special one on their own.
+You might be used to a standard three-step procedure to compile and install programs: `./configure && make && make install`. Kernel modules do not follow it, but have a special one on their own called Kbuild.
 
-As far as the compilation goes, there is no `configure` script. But you also don't have to edit the Makefile; you jump straight to `make` and you're done. The global Makefile can be found in the `mod` folder:
+If your distribution supports the Dynamic Kernel Module Support (DKMS) framework, this can be used in order to compile and build the Jool kernel modules. If however your distribution does not support DKMS, or its use is undesired for some reason, the Jool kernel modules can be built and installed manually by using the Kbuild system directly.
+
+Regardless of which method you use to install the kernel modules, after a successfull installation you will be able to start Jool using `modprobe jool` or `modprobe jool_siit`. The logical next step after that would be to read the [Basic SIIT Tutorial](mod-run-vanilla.html).
+
+### DKMS
+
+The DKMS framework provides a convenient wrapper around the standard kernel Kbuild system. A single DKMS command will perform all the steps necessary in order to use third-party kernel modules such as Jool. It will also ensure that everything is done all over again whenever necessary (such as after a kernel upgrade). DKMS can also be used to create packages for deb/rpm-based distributions containing pre-built Jool kernel modules.
+
+In order to install the Jool kernel modules using DKMS, you need to run `dkms install /path/to/Jool-sourcedir`, like so:
+
+{% highlight bash %}
+user@node:~# apt-get install dkms
+user@node:~$ unzip Jool-<version>.zip
+user@node:~# dkms install Jool-<version>
+{% endhighlight %}
+
+DKMS will now have compiled, installed and indexed the Jool kernel modules; Jool is now ready for use.
+
+### Kbuild
+
+Kbuild is the Linux kernel's standard system for compiling and installing kernel modules. Jool comes with native Kbuild support. As far as the compilation goes, there is no `configure` script. But you also don't have to edit the Makefile; you jump straight to `make` and you're done. The global Makefile can be found in the `mod` folder:
 
 {% highlight bash %}
 user@node:~$ unzip Jool-<version>.zip
@@ -75,11 +96,7 @@ user@node:~$ cd Jool-<version>/mod
 user@node:~/Jool-<version>/mod$ make
 {% endhighlight %}
 
-And that's that.
-
-## Installation
-
-You copy the binaries generated to your system's module pool by running the `modules_install` target:
+The Jool kernel modules are now compiled for your current kernel. Next, copy them to your system's module pool by running the `modules_install` target:
 
 {% highlight bash %}
 user@node:~/Jool-<version>/mod# make modules_install
@@ -98,6 +115,3 @@ You'll later activate the modules using the `modprobe` command. Thing is, the fa
 {% highlight bash %}
 user@node:~# /sbin/depmod
 {% endhighlight %}
-
-Done; Jool can now be started. The logical follow-up is the [Basic SIIT Tutorial](mod-run-vanilla.html).
-

--- a/include/nat64/common/nat64.h
+++ b/include/nat64/common/nat64.h
@@ -14,6 +14,10 @@
 #define MODULE_NAME "SIIT Jool"
 #endif
 
+/**
+ * These defines are read in from dkms.conf. If you change their syntax or
+ * relocate them, please make sure to also update dkms.conf accordingly.
+ */
 #define JOOL_VERSION_MAJOR 3
 #define JOOL_VERSION_MINOR 3
 #define JOOL_VERSION_REV 2


### PR DESCRIPTION
Dynamic Kernel Module Support (DKMS) is a framework used by various
distributions to handle third-party kernel modules such as Jool. It
takes care of all the necessary steps in order to build and install
kernel modules (make, make modules_install, depmod), and will also
ensure these steps are automatically performed all over again
whenever the kernel packages are being upgraded. This is very
convenient in production scenarios, as it prevents the operator from
accidentally ending up with a non-functional Jool installation (due
to missing kernel modules) after installing any pending distribution
updates and subsequently rebooting.

Note: When creating release archives, the PACKAGE_VERSION variable
in dkms.conf should probably be manually updated to hard-code the
version string (i.e., the git tag) of the release in question.