### PR TITLE
support kernel 4.1 or later

### DIFF
--- a/mod/common/core.c
+++ b/mod/common/core.c
@@ -67,7 +67,7 @@ end:
 static bool check_namespace(const struct net_device *dev)
 {
 #ifdef CONFIG_NET_NS
-	if (dev && dev->nd_net != joolns_get())
+	if (dev && dev_net(dev) != joolns_get())
 		return false;
 #endif
 	return true;

--- a/mod/common/namespace.c
+++ b/mod/common/namespace.c
@@ -1,5 +1,6 @@
 #include "nat64/mod/common/namespace.h"
 #include <linux/sched.h>
+#include <linux/err.h>
 #include "nat64/mod/common/types.h"
 
 struct net *jool_net;
@@ -7,9 +8,9 @@ struct net *jool_net;
 int joolns_init(void)
 {
 	jool_net = get_net_ns_by_pid(task_pid_nr(current));
-	if (!jool_net) {
+	if (IS_ERR(jool_net)) {
 		log_err("Could not retrieve the current namespace.");
-		return -ESRCH;
+		return PTR_ERR(jool_net);
 	}
 
 	return 0;

--- a/mod/stateful/nf_hook.c
+++ b/mod/stateful/nf_hook.c
@@ -64,17 +64,25 @@ static char *banner = "\n"
 #endif
 
 static unsigned int hook_ipv4(HOOK_ARG_TYPE hook, struct sk_buff *skb,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+		const struct nf_hook_state *state)
+#else
 		const struct net_device *in, const struct net_device *out,
 		int (*okfn)(struct sk_buff *))
+#endif
 {
-	return core_4to6(skb, in);
+	return core_4to6(skb, skb->dev);
 }
 
 static unsigned int hook_ipv6(HOOK_ARG_TYPE hook, struct sk_buff *skb,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+		const struct nf_hook_state *state)
+#else
 		const struct net_device *in, const struct net_device *out,
 		int (*okfn)(struct sk_buff *))
+#endif
 {
-	return core_6to4(skb, in);
+	return core_6to4(skb, skb->dev);
 }
 
 static struct nf_hook_ops nfho[] = {

--- a/mod/stateless/nf_hook.c
+++ b/mod/stateless/nf_hook.c
@@ -41,17 +41,25 @@ MODULE_PARM_DESC(disabled, "Disable the translation at the beginning of the modu
 #endif
 
 static unsigned int hook_ipv4(HOOK_ARG_TYPE hook, struct sk_buff *skb,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+		const struct nf_hook_state *state)
+#else
 		const struct net_device *in, const struct net_device *out,
 		int (*okfn)(struct sk_buff *))
+#endif
 {
-	return core_4to6(skb, in);
+	return core_4to6(skb, skb->dev);
 }
 
 static unsigned int hook_ipv6(HOOK_ARG_TYPE hook, struct sk_buff *skb,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+		const struct nf_hook_state *state)
+#else
 		const struct net_device *in, const struct net_device *out,
 		int (*okfn)(struct sk_buff *))
+#endif
 {
-	return core_6to4(skb, in);
+	return core_6to4(skb, skb->dev);
 }
 
 static struct nf_hook_ops nfho[] = {


### PR DESCRIPTION
Compile failed in Linux kernel 4.1.

```
$ make
make -C stateless
make[1]: Entering directory `/home/pandax381/LOCAL/NAT64/mod/stateless'
make -C /lib/modules/4.1.7-v7+/build M=$PWD JOOL_FLAGS=""
make[2]: Entering directory `/usr/src/linux-headers-4.1.7-v7+'
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/rfc6145/4to6.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/rfc6145/6to4.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/rfc6145/common.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/rfc6145/core.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/address.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/types.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/str_utils.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/packet.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/stats.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/log_time.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/icmp_wrapper.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/ipv6_hdr_iterator.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/pool6.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/rfc6052.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/nl_buffer.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/rbtree.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/config.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/nl_handler.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/route.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/send_packet.o
  CC [M]  /home/pandax381/LOCAL/NAT64/mod/stateless/../common/core.o
/home/pandax381/LOCAL/NAT64/mod/stateless/../common/core.c: In function 'check_namespace':
/home/pandax381/LOCAL/NAT64/mod/stateless/../common/core.c:70:25: error: invalid operands to binary != (have 'possible_net_t' and 'struct net *')
make[3]: *** [/home/pandax381/LOCAL/NAT64/mod/stateless/../common/core.o] Error 1
make[2]: *** [_module_/home/pandax381/LOCAL/NAT64/mod/stateless] Error 2
make[2]: Leaving directory `/usr/src/linux-headers-4.1.7-v7+'
make[1]: *** [all] Error 2
make[1]: Leaving directory `/home/pandax381/LOCAL/NAT64/mod/stateless'
make: *** [stateless] Error 2
```

The cause is because the API of the callback function of Netfilter has been changed in the kernel 4.1 or later. If the kernel version 4.1 or later, you need to use the new API.

include/linux/netfilter.h (kernel 4.0 or earlier)
```
typedef unsigned int nf_hookfn(const struct nf_hook_ops *ops,
                               struct sk_buff *skb,
                               const struct net_device *in,
                               const struct net_device *out,
                               int (*okfn)(struct sk_buff *));
```

include/linux/netfilter.h (kernel 4.1 or later)
```
typedef unsigned int nf_hookfn(const struct nf_hook_ops *ops,
                               struct sk_buff *skb,
                               const struct nf_hook_state *state);
```